### PR TITLE
Review of material

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,23 @@
+# Configuration
+
+config:
+
+# MD013 - line-length
+  line_length:
+    line_length: 120
+    code_blocks: false
+    tables: false
+  html:
+    allowed_elements:
+      - div
+
+globs:
+
+- "posts/**/*.md"
+- "*.md"
+
+ignores:
+
+- "_site/**/*.md"
+
+fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        args: ['--maxkb=2048']
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.14.0
+    hooks:
+      - id: markdownlint-cli2
+        args: []
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: ["-L fallow"]
+
+ci:
+  autofix_prs: true
+  autofix_commit_msg: '[pre-commit.ci] Fixing issues with pre-commit'
+  autoupdate_schedule: weekly
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit-autoupdate'
+  skip: [] # Optionally list ids of hooks to skip on CI

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,6 +8,5 @@ we pledge to follow the [University of Sheffield Research Software Engineering C
 Instances of abusive, harassing, or otherwise unacceptable behavior
 may be reported by following our [reporting guidelines][coc-reporting].
 
-
 [coc-reporting]: https://rse.shef.ac.uk/community/code_of_conduct#enforcement-guidelines
 [coc]: https://rse.shef.ac.uk/community/code_of_conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contributing
+## Contributing <!-- markdownlint-disable-line MD041 -->
 
 We welcome contributions to this open educational resource: fixes to
 existing material, bug reports, and reviews of proposed changes are all
@@ -46,23 +46,11 @@ use [GitHub flow][github-flow] to manage changes:
 
 NB: The published copy of the lesson is usually in the `main` branch.
 
-
 [repo]: https://github.com/Romain-Thomas-Shef/FAIR_Management_plan
 [repo-issues]: https://github.com/Romain-Thomas-Shef/FAIR_Management_plan/issues
 [contact]: mailto:romain.thomas@sheffield.ac.uk
-[cp-site]: https://carpentries.org/
-[dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
-[dc-lessons]: https://datacarpentry.org/lessons/
-[dc-site]: https://datacarpentry.org/
-[discuss-list]: https://carpentries.topicbox.com/groups/discuss
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://carpentries.org/help-wanted-issues/
-[lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
-[swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
-[swc-lessons]: https://software-carpentry.org/lessons/
-[swc-site]: https://software-carpentry.org/
-[lc-site]: https://librarycarpentry.org/
 [template-doc]: https://carpentries.github.io/workbench/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -49,10 +49,10 @@ Under the following terms:
 
 Notices:
 
-* You do not have to comply with the license for elements of the material in
+- You do not have to comply with the license for elements of the material in
   the public domain or where your use is permitted by an applicable exception
   or limitation.
-* No warranties are given. The license may not give you all of the permissions
+- No warranties are given. The license may not give you all of the permissions
   necessary for your intended use. For example, other rights such as publicity,
   privacy, or moral rights may limit how you use the material.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # The Carpentries Workbench Template Markdown Lesson
 
-This lesson is a template lesson that uses [The Carpentries Workbench][workbench]. 
+This lesson is a template lesson that uses [The Carpentries Workbench][workbench].
 
 ## Note about lesson life cycle stage
-Although the `config.yaml` states the life cycle stage as pre-alpha, **the template is stable and ready to use**. The life cycle stage is preset to `"pre-alpha"` as this setting is appropriate for new lessons initialised using the template.
+
+Although the `config.yaml` states the life cycle stage as pre-alpha, **the template is stable and ready to use**. The
+life cycle stage is preset to `"pre-alpha"` as this setting is appropriate for new lessons initialised using the
+template.
 
 ## Create a new repository from this template
 
-To use this template to start a new lesson repository, 
-make sure you're logged into Github.   
-Visit https://github.com/carpentries/workbench-template-md/generate
+To use this template to start a new lesson repository,
+make sure you're logged into Github.
+Visit <https://github.com/carpentries/workbench-template-md/generate>
 and follow the instructions.
 Checking the 'Include all branches' option will save some time waiting for the first website build
 when your new repository is initialised.
@@ -39,7 +42,7 @@ complete the initial configuration of a new lesson repository built from this te
    - `contact`
 1. **Annotate the repository** with site URL and topic tags:
    navigate back to the repository landing page and
-   click on the gear wheel/cog icon (similar to ⚙️) 
+   click on the gear wheel/cog icon (similar to ⚙️)
    at the top-right of the _About_ box.
    Check the "Use your GitHub Pages website" option,
    and [add some keywords and other annotations to describe your lesson](https://cdh.carpentries.org/the-carpentries-incubator.html#topic-tags)
@@ -48,10 +51,10 @@ complete the initial configuration of a new lesson repository built from this te
    - `lesson`
    - the life cycle of the lesson (e.g. `pre-alpha`)
    - the human language the lesson is written in (e.g. `deutsch`)
-1. **Adjust the 
+1. **Adjust the
    `CITATION.cff`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `LICENSE.md` files**
    as appropriate for your project.
-   -  `CITATION.cff`:
+   - `CITATION.cff`:
       this file contains information that people can use to cite your lesson,
       for example if they publish their own work based on it.
       You should [update the CFF][cff-sandpaper-docs] now to include information about your lesson,
@@ -59,21 +62,21 @@ complete the initial configuration of a new lesson repository built from this te
       author list grows and other details become available or need to change.
       The [Citation File Format home page][cff-home] gives more information about the format,
       and the [`cffinit` webtool][cffinit] can be used to create new and update existing CFF files.
-   -  `CODE_OF_CONDUCT.md`: 
+   - `CODE_OF_CONDUCT.md`:
       if you are using this template for a project outside The Carpentries,
-      you should adjust this file to describe 
+      you should adjust this file to describe
       who should be contacted with Code of Conduct reports,
       and how those reports will be handled.
-   -  `CONTRIBUTING.md`:
+   - `CONTRIBUTING.md`:
       depending on the current state and maturity of your project,
       the contents of the template Contributing Guide may not be appropriate.
       You should adjust the file to help guide contributors on how best
       to get involved and make an impact on your lesson.
-   -  `LICENSE.md`:
+   - `LICENSE.md`:
       in line with the terms of the CC-BY license,
-      you should ensure that the copyright information 
+      you should ensure that the copyright information
       provided in the license file is accurate for your project.
-1. **Update this README with 
+1. **Update this README with
    [relevant information about your lesson](https://carpentries.github.io/lesson-development-training/collaborating-newcomers.html#readme)**
    and delete this section.
 

--- a/episodes/SMP_for_research.md
+++ b/episodes/SMP_for_research.md
@@ -21,76 +21,84 @@ exercises: 0
 
 ## Introduction
 
-A Software Management Plan [SMP] is a framework that outlines how software development, releases, maintenance, and
-support will be conducted throughout its lifecycle. It outlines how the key aspects like goals, ressources, milestone,
-risks, and quality are effectively controlled. The plan is usually created early in the project and is essential for
-both small and large projects to ensure clear communication and expectations among team members.
+A Software Management Plan (SMP) is a framework that outlines how software development, releases, maintenance, and
+support will be conducted throughout its lifecycle. It outlines how the key aspects like goals, resources, milestones,
+risks, and quality are effectively controlled. The plan is usually created early in the project, ideally before work is
+undertaken, and is essential for both small and large projects to ensure clear communication and expectations among team
+members.
 
-In this chapter we present various point that you might want to think about when you start developing a code for
-research. The goal is that you ask yourself the right questions before embarking in an important software development
-journey.
+This chapter presents various point that you should think about when you start developing code for research. The goal is
+that you ask yourself the right questions before embarking on your software development journey.
 
 ## Software Management Plan
 
-Research is quite different from private sector. The goal of a research software is to answer a research question in a
-way that allows other people (and yourself) to carry it forward. Aligning the SMP to the research lifecyle ensure that
+Research is quite different from the private sector. The goal of a research software is to answer a research question in
+a way that allows other people (and yourself) to carry it forward. Aligning the SMP to the research lifecycle ensures that
 the software not only facilitates scientific progress but also meets academics standards for collaboration,
 documentation and reproducibility.
 
 ### Project Overview
 
-You will not start a research software without having a research question you want to answer. Instead of business
-requirement that you would have a in traditional software lifecycle you should gather research objectives. Having a
-clear research question will greatly help you define your software.
+You will not start a research software project without having a research question you want to answer. Instead of business
+requirement that you would have in a traditional software lifecycle you should therefore gather research
+objectives. Having a clear research question will greatly help you define the requirements for your software.
 
-Then what would you do? The answer is the same as for the research question: you look at what is already out there in
-the literature. If someone had already answered your research question then you would not try to answer it again. So for
-a research software you should do the same: you will first look at what is already available. The case where people are
-reimplemeting something that already exist is far too common and waste a lot of previous research time and founding. In
-short: **DO NOT RE-INVENT THE WHEEL**. If something is already available but does not have all the functionalities you
-are looking for then maybe you can build upon that previous work. If the code is open source, you might just be able to
-clone it and carry it forward (as long as you give credit to the original author). Alternatively you may be able to
-contribute features up-stream to the package you wish to use. If it is not open source, you might
-be able to contact the author and ask if you can have access to the source code (you might create new collaborations!).
+But how do you proceed? The answer is the same as for the research question: you look at what is already out there in
+the literature and software ecosystem of your domain. If someone has already answered your research question then you
+typically  would not try to answer it again (unless seeking to replicate the finding). The same is true for research
+software: you will first look at what is already available. The case where people are  re-implementing something that
+already exist is far too common and wastes a lot of previous research time and funding. In short: **DO NOT RE-INVENT THE
+WHEEL**. If something is already available but does not have all the functionalities you are looking for then maybe you
+can build upon that previous work. If the code is open source, you might just be able to clone it and carry it forward
+(as long as you give credit to the original author). Alternatively you may be able to contribute features up-stream to
+the package you wish to use at the same time forging connections and potential collaborations. If it is not open source,
+you might be able to contact the author and ask if you can have access to the source code, again this may lead to
+fruitful collaborations!
 
 If you still want to create something from scratch when something already exists, always ask yourself: what would make
 people use my solution instead of the one that is already available? What benefits will my software bring to the
 research community?
 
+When you have a good sense of what you want to create you must define what data will be used as input and what the
+output of the software will look like. It is common that for a given domain some data standard are already in use. Try
+to stick to these standards as much as you can as doing so will make your software more **Interoperable** with other systems
+and **Reusable** by others.
 
-When you have a good sense of what you want to create you must define what will be the data that will be used and output
-of the tool. It often happens that for a given domain some data standard are in use. Try to stick to these standards as
-much as you can and you will make your software more **interoperable** with other systems and **reusable** by others.
-
-### Human and Technical ressouces
+### Human and Technical resources
 
 Once you have a good idea of what you want to create, the next step is to identify who is in charge of it. Identify team
-members (P.I, RSE, Postdocs, PhD students) and their roles in the development of the tool. It is often useful to extend
-these distribution of roles to other aspects of the project, such as data management & publication (it is important that
-everybody gets credit for their work and **can evidence it**). Doing this before you start you will identify what are
-the skills available in your team and what are the missing ones, hence identifying the needs for training. Discussing
-these aspects beforehand will make you save time and potentialy avoid some painful discussions (and frustrations) down
-the line.
+members (e.g. P.I, Research Software Engineers (RSE), Postdocs, PhD students) and define their roles in the development
+of the tool. It is often useful to extend the distribution of roles to other aspects of the project, such as data management
+& publication (it is important that everybody gets credit for their work and **can evidence it**). Doing this before you
+start you will help you identify what skills are available in your team and what, if any, deficiencies there are and
+hence identifying the needs for training. Discussing these aspects beforehand will save you time and potentially help avoid
+some painful discussions (and frustrations) down the line.
 
-One crucial aspect of a software project, especially occuring in research, is the problem of the bus factor. Simply put
-the bus factor is a number equal to the amount of people in your project that could get it by a bus without putting your
-project in trouble. The worst bus factor is 1 and means a single person is in charge of everything. If you lose that
-person that project stops. Trying to mitigate this bus factor is crucial, and sometimes very hard to do. You might want
-to have different people aware of the code(through peer code review in the team), and what will be very important is to
-have a very clean and up-to-date documentation (the lecture on [Documentation] might help you do that).
+One crucial aspect of a software project, especially occurring in research, is the problem of the [bus
+factor][busfactor]. Simply put it is a measurement of risk that arises if a member of the team were "_hit by a bus_" and
+the information and capabilities they hold about the project has not been shared with the team.  The worst bus factor is
+1 and means a single person is in charge of everything. If you lose that person then the project stops as no one else
+knows about the project or has the skills to continue working on it. The higher the bus number the better as it means
+there is shared knowledge and skills within the team. However, trying to mitigate this bus factor is crucial, and
+sometimes very hard to do, particularly in smaller research groups. There are some steps that can be taken though, for
+example you might want to have different people within the team familiar with the code. This can be achieved through
+regular peer review during the development cycle. Perhaps most important is to have very clear and up-to-date
+documentation on what the software does and how it is used.  The module on [Documentation][documentation] will be
+helpful in how to go about this.
 
-On the technical side, it is important to identify technical resources, e.g. computing environement, High Performance
-Computing platform, that might be available. You might not see their need at first, but as the development goes on, if
-you know what support you can get from your own institution it is always interesting to know where and how accessible
-they are (some might need financing that you need to plan in advance!).
+On the technical side, it is important to identify technical resources, e.g. computing environment, High Performance
+Computing platform, that might be available. You might not see their need at first, but as development proceeds if
+you know what support you can get from your own institution it will be useful know where and how accessible the support
+is  as some, such as Research Software Engineer support, may need financing and you would need to plan this in advance
+as part of the budget.
 
 ### Development Approach
 
 How will you develop your code? Multiple ways exist to manage the development of a software, we can name two here:
 
-- [Waterfall][waterfall]: This approach is a linear and sequential project management technique where each phase depends on the
-  completion of the previous one. It consists of stages like requirements gathering, design, implementation, testing,
-  deployment, and maintenance. Progress flows in one direction, similar to a waterfall. Changes are difficult to
+- [Waterfall][waterfall]: This approach is a linear and sequential project management technique where each phase depends
+  on the completion of the previous one. It consists of stages like requirements gathering, design, implementation,
+  testing, deployment, and maintenance. Progress flows in one direction, similar to a waterfall. Changes are difficult to
   implement once a phase is completed. It is best suited for projects with well-defined requirements and minimal
   expected changes.
 
@@ -101,119 +109,131 @@ How will you develop your code? Multiple ways exist to manage the development of
   projects with evolving requirements.
 
 Whatever method of project management you choose, ensure that it is fostering collaboration within the group. Both have
-their advantages but keep in mind that research is an iterative provess involving a lot of trials/errors cycle and
-experimentations. Communication will be a key aspect of success. It might be interesting to have short development
-cycles with an iterative approach (hence an Agile style might be more suitable). This will help you analyse intermediary
-research outcomes, review the development of the software (and documentation) and overall progress. It is not rare that
-while developing a research tool with a clear goal in mind you end up finding serendipitous results that are worth a
-publication!
+their advantages but keep in mind that research is an iterative provess involving a lot of trial-and-error cycles and
+experimentation. Communication will be a key aspect of success. It might be interesting to have short development
+cycles with an iterative approach in which case an Agile approach would be more suited. This will help you analyse
+intermediary research outcomes, review the development of the software (and documentation) and overall progress and
+regularly review and realign the goals if necessary. It is not rare that while developing a research tool with a clear
+goal in mind you end up finding serendipitous results that are worthy of publication in their own right!
 
-In addition, what tools are you using for software development? Do not end up with multiple files for the multiple
-version of your software (e.g. version1, version 1_1, version1_2, version1_final, version1_final2, etccc). It will
-become unmanageable. To avoid such a situation, it is important to have a version control tool that allows you to track
-the changes that you implement in your software. Some lectures on this program could help with this: [Git-beginners] &
-[Git-collaboration]. Using version control will help making your software more **FAIR** (all letters!).
-
+The tools are you use for software development are also very important. Do not end up with multiple files for the multiple
+version of your software (e.g. version1, version 1_1, version1_2, version1_final, version1_final2, etc.). It will
+become unmanageable. To avoid this situation, it is important to have a version control tool that allows you to track
+the changes that you implement in your software over time. Using version control will help making your software more
+**FAIR**. If you are unfamiliar with version control then the modules on [Git for Beginners][gitzerohero] and
+[Git Collaboration][gitcollaboration] will be useful.
 
 ### Timeline and Milestones
 
-Creating a software is not easy. The bigger it gets, the more complicated it becomes. Hence it is important to have
-checkpoints, or milestones, that you can work toward. It is often possible to split the development of a research into
-multiple intermediary states. These intermediary states will give you more realistic and achievable objectives and allow
-you to track the work. This will create your development timeline.
+Creating software is not easy. The bigger it gets, the more complicated it becomes. Hence it is important to have
+checkpoints, or milestones, that you can work toward. It is often possible to split the development of a software
+package into multiple intermediary states. These intermediary states will give you more realistic and achievable
+objectives and allow you to track progress and allow you to create your development timeline.
 
-In addition, it is important to coordinate this timeline with research milestones and deadlines. They can be paper submissions, conference presentations, funding milestones, PhD thesis milestones. Software development and research progress should be as aligned as possible and tracked concurently. If they diverge you will be in trouble.
+It is important to coordinate this timeline with research milestones and deadlines. They can be paper
+submissions, conference presentations, funding deadlines, PhD thesis submissions. Software development and research
+progress should be as aligned as possible and tracked concurrently. If they diverge you will be in trouble.
 
 ### Risk Management
 
 **Spoiler alert: nothing will work from the first try!** You will inevitably encounter blockers which hinder progress
 during the development of your software and only some of these will be identifiable beforehand. Failure to achieve
-scientific outcomes, data issues (sometimes data will never come!), reproducibility failures, or tool/library
-obsolescence are example of such risks.
+scientific outcomes, data issues (sometimes data will never arrive!), reproducibility failures, or tool/library
+obsolescence are examples of risks that can be anticipated.
 
 Once identified, you should think about how to mitigate these risks and create a contingency plan (a plan B) in case
-they turn out to be real problems (e.g., backup strategies for data and code, alternative methods).
+they turn out to be real problems (e.g. backup strategies for data and code, alternative methods).
 
-One important aspect of research it is that it is hard to plan. So how will you address changes in the research
-hypothesis, data, or experimental design and how might that impact the software. Ensure proper version control for both
-code and datasets and allow for flexibility for exploratory research where new insights might lead to changes in the
-software. This gets much easier when the code is written in a maintainable, readable and **Reusable** way (The lecture
-on [Design your code] might be helpful for this).
-
+One important aspect of research it is that it is hard to plan. So how you address changes in the research hypothesis,
+data, or experimental design and how this might impact software development is important to consider. Ensure proper
+version control for both code and datasets and allow for flexibility for exploratory research where new insights might
+lead to changes in the software. This gets much easier when the code is written in a maintainable, readable and
+**Reusable** way. If unfamiliar with software development the module on [Design your code][codedesign] will be useful.
 
 ### Quality Assurance
 
-Wouldn’t it be sad that all the work you have been putting in your software development is wasted by a typo in the code?
-How do you make sure that the code you are writing is doing things as it is intended to be done? And that the scientific
-results your producing are reliable and reproducible?
+Wouldn’t it be sad if all the work you have been putting in your software development is wasted by a typo in the code?
+How do you make sure that the code you are writing is functioning as intended and that the scientific results your
+producing are reliable and reproducible?
 
-Develop strategies to ensure both code quality and research reproducibility:
+There are some strategies to ensure both code quality and research reproducibility:
 
-- The code quality can be checked by doing code peer reviews. Regular peer review are very helpful both for increasing
-  the quality and for disseminating knowledge in the team (reducing the bus factor). Automated testing with continuous
-  integration (You can find a lecture on [testing] and continuous integration in the program), version control
-  ([Git-beginners][gitzerohero] & [Git-collaboration][gitcollaboration]), etc…
+- **Peer Review** : Code quality can be checked by doing code peer reviews. Regular peer review are very helpful both
+  for increasing the quality and for disseminating knowledge in the team (reducing the bus factor). Automated testing
+  with continuous integration. There are modules on [testing and continuous integration][pythontesting] and version
+  control ([Git for Beginners][gitzerohero] and [Git Collaboration][gitcollaboration]) that can be undertaken.
 
-- Research reproducibility will also benefit from all of the previous suggestions, but you can add data version control (DVC) that will help track the state of your data and changes, parametrisation of code ensures that it can be rerun with different parameters easily (without changing the code) via configuration files or command line interface (follow the lecture on [Design] for these aspects). Testing by other people also helps. If someone else in your team can reproduce your results it will give you a good idea of how reproducible are your results. Finally, and for a more advanced case, it is possible to fully automatise reproducibility checks.
+- **Data Version Control** : Reproducibility will benefit from the previous suggestions, but you can also adopt a strategy
+  for data version control (DVC) that will help track the state of your data and changes. Parametrisation of code
+  ensures that it can be rerun with different parameters easily (without changing the code) via configuration files or
+  command line interface. The module on [Code Design][codedesign] covers how to do this.
 
-* Reliability of science results can be tested by comparing your code with exsiting datasets. Can you replicate exiting
-  results with your own tool? That will give you an interesting insight.
+- **User Testing** : Testing by other people also helps. If someone else in your team can reproduce your results it will
+  give you a good idea of how reproducible are your results. For a more advanced case, it is possible to fully
+  automatise reproducibility checks and strategies for this are covered in the [testing and continuous
+  integration][pythontesting] module.
 
-A Tested software make it more reliable and robust. You will greatly enhance its **Reusability** and make your science more **Reproducible**.
+- **Reliability** : The reliability of scientific output can be tested by comparing your code with existing
+  datasets. Can you replicate existing results with your own tool? That will give you an interesting insight.
 
-### Dissemination.
+Tested software is more reliable and robust and thorough testing of your code will greatly enhance its **Re-usability**
+and make your science more **Reproducible**.
+
+### Dissemination
 
 Dissemination is a cornerstone of research. When it comes to research software you will have to make sure that people
-know where to find it and how to use it (**Findable** and **Reusable**). It comes down to three important pilars:
+know where to find it and how to use it (**Findable** and **Reusable**). It comes down to three important pillars:
 
-* License: This is probably one of the most basic item of the software management plan. If there is no license in your
-  software people won't know if they have the right to re-use your software. No license means that you retain all the
-  rights to your source code and no one may reproduce, distribute or create derivative works from your code (which is
+- **License**: This is probably one of the most basic items of the software management plan. If there is no license for
+  your software people won't know if they have the right to reuse your software. No license means that you retain all
+  the rights to your source code and no one may reproduce, distribute or create derivative works from your code (which is
   the opposite of research philosophy). Please see the chapter on intellectual property and software licenses for more
   details **[link TBD]**.
 
-* Documentation is paramount: And guess what, the main group that it will help is YOUR TEAM! Research projects often
-  span several years with people coming in and some leaving the team. If it takes someone 6 months just to understand
-  the software that the team is developing it is going to be a waste of time. If you want a sustainable project, write a
-  good documentation. In addition, If you produce a software with a good documentation it will be more likely used by
-  the community and then you might get credit for it! You should make sure that the documentation is easily accessible
-  (e.g. a website) and tailored to future researchers and the academic community in your research domain (Lecture on
-  [Documentation] is available in the program). Document how the software works, but not only this. Always describe how
-  it serves a research question.
+- **Documentation** is paramount, the main group that will help is your future self and members of your team! Research
+  projects often span several years during which new members will join and some will leave the team. If it takes someone
+  6 months just to understand the software that the team is developing that is wasted time. If you want a sustainable
+  project, write good documentation. In addition, If you produce software with a good documentation it will be more
+  likely used by the community and then you might get credit for it! Make sure that the documentation is easily
+  accessible (e.g. a website) and tailored to future researchers and the academic community in your research domain. You
+  should describe the research question the software seeks to solve as well as how the software works and should be
+  used. The module on [Documentation][documentation] covers advice on how to document software projects.
 
-* Software repositories: It is important to place your software (the released version) to a place where people can
-  download it freely. Collaborative development platform such as github are not made to store software on the long
-  term. Nevertheless, other platform are made for this (e.g. figshare, zenodo, etc..). This is where you should look for
-  a long term storage. Please see chapter on dissemination for more details **[Link TBD]**.
+- **Software Repositories**: It is important to place your software (the released version) to a place where people can
+  download it freely. Collaborative development platform such as [Github][gh] and [GitLab][gl] are not made to store
+  software on the long term. More persistent platforms designed for the sharing of research output exist such as
+  [Figshare][figshare] and [Zenodo][zenodo] and should be used for long term storage of software. Please see chapter on
+  dissemination for more details **[Link TBD]**.
 
 To go a little bit further, you might want to take extra step in the dissemination direction:
 
-* Publication: Once you release your software, you might want to publish it! Numerous journals accept papera about
-  research software. Some are generalists (e.g. JOSS, JORS, SoftwareX, etc) and some are domain oriented (you can get a
-  non exhaustive list [here](https://www.software.ac.uk/top-tip/which-journals-should-i-publish-my-software)). This is
-  really something you should consider! It will give you a lot of visibility and allow you to get a citable paper
-  associated to your software (you can follow the lecture on [Publishing your software] for this).
+- **Publication**: Once you release your software, you might want to publish it! Numerous journals accept papera about
+  research software. Some are generalists (e.g. [JOSS][joss], JORS, [SoftwareX][softwarex] to name a few) and some are
+  domain oriented (you can get a non-exhaustive list [here][softwarepublishing])). A dedicated paper describing your
+  software is really something you should consider! It will give you a lot of visibility and allow you to get a citable
+  paper associated to your software (you can follow the lecture on [Publishing your software] for this).
 
-* Training: If your software sees a lot of buy-in in the community and that is relatively complex to use (not all
-  software are), you might want to train others to use it. You can do that via tutorials or training events. This is a
-  very powerful way to give your work more visibility and a very efficient way to create collaborations!
-
+- **Training**: If your software sees a lot of buy-in from the community and is relatively complex to use (not all
+  software is), you might want to train others to use it. You can do that via tutorials and/or training events. This is
+  a very powerful way to give your work more visibility and a very efficient way to create collaborations!
 
 ### Long term sustainability
-Maintenance of the software is tricky. We can distinguish two parts:
 
-* The software is in a final form, but the founding is still there: In that case it is important to identify who is in
-  charge of the maintenance and update. You might work with totally different people than at the beginning of the
-  project. So it is important to plan this ahead (cf previous section). A good documentation will always help the
-  maintenance.
+Maintenance of the software is tricky. There are two possible scenarios:
 
-* The research project comes to an end (and with it, its founding). That’s the tricky situation, long term maintenance
-  is difficult because founders do not plan for this (which happens everywhere). If you want to increase the chances
-  that your software work in 5 or 10 years, what you could envisage to do is to distribute your software with its own
+- The software is in a final form, but the funding is still there: In that case it is important to identify who is in
+  charge of the maintenance and update. You might be working with totally different people than at the beginning of the
+  project. So it is important to plan ahead for this in the Software Management Plan.
+
+- The research project comes to an end (and with it, its founding). That’s the tricky situation, long term maintenance
+  is difficult because funders do not plan for this (which happens everywhere). If you want to increase the chances
+  that your software works in 5 or 10 years, what you could envisage to do is to distribute your software with its own
   computational environment. This ships your software with the required dependencies and put all this in its own
-  bubble. This greatly enhance long term **Reproducibility** of your work. If you are interested to learn more about
-  this, you can register to the lecture on [Reproducible Computational Environment].
+  bubble. This greatly enhances the long term **Reproducibility** of your work. If you are interested to learn more about
+  this, you can enrol in the [Reproducible Computational Environment][reprocompenv].
 
+In either scenario having accessible and detailed documentation will be really useful for the long term maintenance of
+the code.
 
 ## Minimal version
 
@@ -229,8 +249,19 @@ items to put in place you could use the following:
 
 These four items should be on your list in the planning phase.
 
-
 [agile]: https://en.wikipedia.org/wiki/Agile_software_development
+[busfactor]: https://en.wikipedia.org/wiki/Bus_factor
+[codedesign]: https://romain-thomas-shef.github.io/FAIR_Code_design/
+[documentation]: https://joe-heffer-shef.github.io/FAIR4RS-Documentation/
+[figshare]: https://figshare.com/
+[gh]: https://github.com/
+[gl]: https://gitlab.com/
 [gitzerohero]: https://srse-git-github-zero2hero.netlify.app/
 [gitcollaboration]: https://blog.nshephard.dev/git-collaboration/
-[watefall]: https://en.wikipedia.org/wiki/Waterfall_model
+[joss]: https://joss.theoj.org/
+[pythontesting]: https://sylviawhittle.github.io/python-testing-for-research/
+[reprocompenv]: https://ubdbra001.github.io/FAIR4RS-VirtualEnvs/
+[softwarepublishing]: https://www.software.ac.uk/top-tip/which-journals-should-i-publish-my-software
+[softwarex]: https://www.sciencedirect.com/journal/softwarex
+[waterfall]: https://en.wikipedia.org/wiki/Water_model
+[zenodo]: https://zeondo.org

--- a/episodes/SMP_for_research.md
+++ b/episodes/SMP_for_research.md
@@ -4,123 +4,233 @@ teaching: 10
 exercises: 0
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
 - What should you ask yourself before starting a software project?
+- How do I write a Software Management Plan?
+- How do I disseminate my work and make it findable?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: objectives
 
-- Understand what are the main points of a software management plan.
-- What are they main question you should ask yourself before diving into the coding part.
+- Understand the main points of a software management plan.
+- What are the main questions you should ask yourself before diving into the coding part.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Introduction
 
-A Software management plan [SMP] is a framework that outlines how software development, releases, maintenance, and support will be conducted throughout its lifecycle. It outlines how the key aspects like goals, ressources, milestone, risks, and quality are effectively controlled. The plan is usually created early in the project and is essential for both small and large projects to ensure clear communication and expectations among team members.  
+A Software Management Plan [SMP] is a framework that outlines how software development, releases, maintenance, and
+support will be conducted throughout its lifecycle. It outlines how the key aspects like goals, ressources, milestone,
+risks, and quality are effectively controlled. The plan is usually created early in the project and is essential for
+both small and large projects to ensure clear communication and expectations among team members.
 
-In this chapter we present various point that you might want to think about when you start developing a code for research. The goal is that you ask yourself the right questions before embarking in an important software development journey. 
+In this chapter we present various point that you might want to think about when you start developing a code for
+research. The goal is that you ask yourself the right questions before embarking in an important software development
+journey.
 
 ## Software Management Plan
 
-Research is quite different from private sector. The goal of a research software is to answer a research question in a way that allows other people (and yourself) to carry it forward. Aligning the SMP to the research lifecyle ensure that the software not only facilitates scientific progress but also meets academics standards for collaboration, documentation and reproducibility.
+Research is quite different from private sector. The goal of a research software is to answer a research question in a
+way that allows other people (and yourself) to carry it forward. Aligning the SMP to the research lifecyle ensure that
+the software not only facilitates scientific progress but also meets academics standards for collaboration,
+documentation and reproducibility.
 
 ### Project Overview
 
-You will not start a research software without having a research question you want to answer. Instead of business requirement that you would have a in traditional software lifecycle you should gather research objectives. Having a clear research question will greatly help you define your software. 
+You will not start a research software without having a research question you want to answer. Instead of business
+requirement that you would have a in traditional software lifecycle you should gather research objectives. Having a
+clear research question will greatly help you define your software.
 
-Then what would you do? The answer is the same as for the research question: you look at what is already out there in the literature. If someone had already answered your research question then you would not try to answer it again. So for a research software you should do the same: you will first look at what is already available. The case where people are reimplemeting something that already exist is far too common and waste a lot of previous research time and founding. In short: **DO NOT RE-INVENT THE WHEEL**. If something is already available but does not have all the functionalities you are looking for then maybe you can build upon that previous work. If the code is open source, you might just be able to clone it and carry it forward (as long as you give credit to the original author). If it is not open source, you might be able to contact the P.I. and ask if you can have access to the source code (you might create new collaborations!). 
+Then what would you do? The answer is the same as for the research question: you look at what is already out there in
+the literature. If someone had already answered your research question then you would not try to answer it again. So for
+a research software you should do the same: you will first look at what is already available. The case where people are
+reimplemeting something that already exist is far too common and waste a lot of previous research time and founding. In
+short: **DO NOT RE-INVENT THE WHEEL**. If something is already available but does not have all the functionalities you
+are looking for then maybe you can build upon that previous work. If the code is open source, you might just be able to
+clone it and carry it forward (as long as you give credit to the original author). Alternatively you may be able to
+contribute features up-stream to the package you wish to use. If it is not open source, you might
+be able to contact the author and ask if you can have access to the source code (you might create new collaborations!).
 
-If you still want to create something from scratch while something already exists, always ask yourself: what would make people use my solution instead of the one that is already available? What addition does my software bring to the research community?
+If you still want to create something from scratch when something already exists, always ask yourself: what would make
+people use my solution instead of the one that is already available? What benefits will my software bring to the
+research community?
 
 
-When you have a good sense of what you want to create you must define what will be the data that will be used and output of the tool. It often happens that for a given domain some data standard are in use. Try to stick to these standards as much as you can and you will make your software more **interoperable** with other systems and **reusable** by others.
+When you have a good sense of what you want to create you must define what will be the data that will be used and output
+of the tool. It often happens that for a given domain some data standard are in use. Try to stick to these standards as
+much as you can and you will make your software more **interoperable** with other systems and **reusable** by others.
 
 ### Human and Technical ressouces
 
-Once you have a good idea of what you want to create, the next step is to identify who is in charge of it. Identify team members (P.I, RSE, Postdocs, PhD students) and their roles in the development of the tool. It is often useful to extend these distribution of roles to other aspects of the project, such as data management & publication (it is important that everybody gets credit for their work and **can evidence it**). Doing this before you start you will identify what are the skills available in your team and what are the missing ones, hence identifying the needs for training. Discussing these aspects beforehand will make you save time and potentialy avoid some painful discussions (and frustrations) down the line. 
+Once you have a good idea of what you want to create, the next step is to identify who is in charge of it. Identify team
+members (P.I, RSE, Postdocs, PhD students) and their roles in the development of the tool. It is often useful to extend
+these distribution of roles to other aspects of the project, such as data management & publication (it is important that
+everybody gets credit for their work and **can evidence it**). Doing this before you start you will identify what are
+the skills available in your team and what are the missing ones, hence identifying the needs for training. Discussing
+these aspects beforehand will make you save time and potentialy avoid some painful discussions (and frustrations) down
+the line.
 
-One crucial aspect of a software project, especially occuring in research, is the problem of the bus factor. Simply put the bus factor is a number equal to the amount of people in your project that could get it by a bus without putting your project in trouble. The worst bus factor is 1 and means a single person is in charge of everything. If you lose that person that project stops. Trying to mitigate this bus factor is crucial, and sometimes very hard to do. You might want to have different people aware of the code(through peer code review in the team), and what will be very important is to have a very clean and up-to-date documentation (the lecture on [Documentation] might help you do that). 
+One crucial aspect of a software project, especially occuring in research, is the problem of the bus factor. Simply put
+the bus factor is a number equal to the amount of people in your project that could get it by a bus without putting your
+project in trouble. The worst bus factor is 1 and means a single person is in charge of everything. If you lose that
+person that project stops. Trying to mitigate this bus factor is crucial, and sometimes very hard to do. You might want
+to have different people aware of the code(through peer code review in the team), and what will be very important is to
+have a very clean and up-to-date documentation (the lecture on [Documentation] might help you do that).
 
-On the technical side, it is important to identify technical resources, e.g. computing environement, High Performance Computing platform, that might be available. You might not see their need at first, but as the development goes on, if you know what support you can get from your own institution it is always interesting to know where and how accessible they are (some might need financing that you need to plan in advance!). 
+On the technical side, it is important to identify technical resources, e.g. computing environement, High Performance
+Computing platform, that might be available. You might not see their need at first, but as the development goes on, if
+you know what support you can get from your own institution it is always interesting to know where and how accessible
+they are (some might need financing that you need to plan in advance!).
 
 ### Development Approach
 
 How will you develop your code? Multiple ways exist to manage the development of a software, we can name two here:
 
-* Waterfall: This approach is a linear and sequential project management technique where each phase depends on the completion of the previous one. It consists of stages like requirements gathering, design, implementation, testing, deployment, and maintenance. Progress flows in one direction, similar to a waterfall. Changes are difficult to implement once a phase is completed. It is best suited for projects with well-defined requirements and minimal expected changes.
+- [Waterfall][waterfall]: This approach is a linear and sequential project management technique where each phase depends on the
+  completion of the previous one. It consists of stages like requirements gathering, design, implementation, testing,
+  deployment, and maintenance. Progress flows in one direction, similar to a waterfall. Changes are difficult to
+  implement once a phase is completed. It is best suited for projects with well-defined requirements and minimal
+  expected changes.
 
-* Agile: This approach is an iterative and flexible project management technique focused on delivering small, incremental improvements. It encourages collaboration between cross-functional teams, frequent feedback, and continuous adaptation to changes. Work is divided into short cycles called sprints, with regular reviews to assess progress. Agile prioritizes customer satisfaction through early and continuous delivery. It is best suited for dynamic projects with evolving requirements.
+- [Agile][agile]: This approach is an iterative and flexible project management technique focused on delivering small,
+  incremental improvements. It encourages collaboration between cross-functional teams, frequent feedback, and
+  continuous adaptation to changes. Work is divided into short cycles called sprints, with regular reviews to assess
+  progress. Agile prioritizes customer satisfaction through early and continuous delivery. It is best suited for dynamic
+  projects with evolving requirements.
 
-Whatever method of project management you choose, ensure that it is fostering collaboration within the group. Both have their advantages but keep in mind that research is an iterative provess involving a lot of trials/errors cycle and experimentations. Communication will be a key aspect of success. It might be interesting to have short development cycles with an iterative approach (hence an Agile style might be more suitable). This will help you analyse intermediary research outcomes, review the development of the software (and documentation) and overall progress. It is not rare that while developing a research tool with a clear goal in mind you end up finding serendipitous results that are worth a publication! 
+Whatever method of project management you choose, ensure that it is fostering collaboration within the group. Both have
+their advantages but keep in mind that research is an iterative provess involving a lot of trials/errors cycle and
+experimentations. Communication will be a key aspect of success. It might be interesting to have short development
+cycles with an iterative approach (hence an Agile style might be more suitable). This will help you analyse intermediary
+research outcomes, review the development of the software (and documentation) and overall progress. It is not rare that
+while developing a research tool with a clear goal in mind you end up finding serendipitous results that are worth a
+publication!
 
-In addition, what tools are you using for software development? Do not end up with multiple files for the multiple version of your software (e.g. version1, version 1_1, version1_2, version1_final, version1_final2, etccc). It will become unmanageable. To avoid such a situation, it is important to have a version control tool that allows you to track the changes that you implement in your software. Some lectures on this program could help with this: [Git-beginners] & [Git-collaboration]. Using version control will help making your software more **FAIR** (all letters!).
+In addition, what tools are you using for software development? Do not end up with multiple files for the multiple
+version of your software (e.g. version1, version 1_1, version1_2, version1_final, version1_final2, etccc). It will
+become unmanageable. To avoid such a situation, it is important to have a version control tool that allows you to track
+the changes that you implement in your software. Some lectures on this program could help with this: [Git-beginners] &
+[Git-collaboration]. Using version control will help making your software more **FAIR** (all letters!).
 
 
 ### Timeline and Milestones
 
-Creating a software is not easy. The bigger it gets, the more complicated it becomes. Hence it is important to have checkpoints, or milestones, that you can work toward. It is often possible to split the development of a research into multiple intermediary states. These intermediary states will give you more realistic and achievable objectives and allow you to track the work. This will create your development timeline. 
+Creating a software is not easy. The bigger it gets, the more complicated it becomes. Hence it is important to have
+checkpoints, or milestones, that you can work toward. It is often possible to split the development of a research into
+multiple intermediary states. These intermediary states will give you more realistic and achievable objectives and allow
+you to track the work. This will create your development timeline.
 
-In addition, it is important to coordinate this timeline with research milestones and deadlines. They can be paper submissions, conference presentations, funding milestones, PhD thesis milestones. Software development and research progress should be as aligned as possible and tracked concurently. If they diverge you will be in trouble.  
+In addition, it is important to coordinate this timeline with research milestones and deadlines. They can be paper submissions, conference presentations, funding milestones, PhD thesis milestones. Software development and research progress should be as aligned as possible and tracked concurently. If they diverge you will be in trouble.
 
 ### Risk Management
 
-**Spoiler alert: nothing will work from the first try!** You will find blockades on the way and some can be identified beforehand. Failure to achieve scientific outcomes, data issues (sometimes data will never come!), reproducibility failures, or tool/library obsolescence are example of such risks.
+**Spoiler alert: nothing will work from the first try!** You will inevitably encounter blockers which hinder progress
+during the development of your software and only some of these will be identifiable beforehand. Failure to achieve
+scientific outcomes, data issues (sometimes data will never come!), reproducibility failures, or tool/library
+obsolescence are example of such risks.
 
-Once identified, you should think how to mitigate these risks and create a contingency plan (a plan B) in case they turn out to be real problems (e.g., backup strategies for data and code, alternative methods).
+Once identified, you should think about how to mitigate these risks and create a contingency plan (a plan B) in case
+they turn out to be real problems (e.g., backup strategies for data and code, alternative methods).
 
-One important aspect of research it is that it is hard to plan. So how will you address changes in the research hypothesis, data, or experimental design and how might that impact the software. Ensure proper version control for both code and datasets and allow for flexibility for exploratory research where new insights might lead to changes in the software. This gets much easier when the code is written in a maintainable, readable and **Reusable** way (The lecture on [Design your code] might be helpful for this).
+One important aspect of research it is that it is hard to plan. So how will you address changes in the research
+hypothesis, data, or experimental design and how might that impact the software. Ensure proper version control for both
+code and datasets and allow for flexibility for exploratory research where new insights might lead to changes in the
+software. This gets much easier when the code is written in a maintainable, readable and **Reusable** way (The lecture
+on [Design your code] might be helpful for this).
 
 
 ### Quality Assurance
 
-*Wouldn’t it be sad that all the work you have been putting in your software development is wasted by a typo in the code?* How do you make sure that the code you are writing is doing things as it is intended to be done? And that the scientific results your producing are reliable and reproducible?  
+Wouldn’t it be sad that all the work you have been putting in your software development is wasted by a typo in the code?
+How do you make sure that the code you are writing is doing things as it is intended to be done? And that the scientific
+results your producing are reliable and reproducible?
 
 Develop strategies to ensure both code quality and research reproducibility:
-* The code quality can be checked by doing code peer reviews. Regular peer review are very helpful both for increasing the quality and for disseminating knowledge in the team (reducing the bus factor). Automated testing with continuous integration (You can find a lecture on [testing] and continuous integration in the program), version control ([Git-beginners] & [Git-collaboration]), etc… 
 
-* Research reproducibility will also benefit from all of the previous suggestions, but you can add data version control (DVC) that will help track the state of your data and changes, parametrisation of code ensures that it can be rerun with different parameters easily (without changing the code) via configuration files or command line interface (follow the lecture on [Design] for these aspects). Testing by other people also helps. If someone else in your team can reproduce your results it will give you a good idea of how reproducible are your results. Finally, and for a more advanced case, it is possible to fully automatise reproducibility checks.  
+- The code quality can be checked by doing code peer reviews. Regular peer review are very helpful both for increasing
+  the quality and for disseminating knowledge in the team (reducing the bus factor). Automated testing with continuous
+  integration (You can find a lecture on [testing] and continuous integration in the program), version control
+  ([Git-beginners][gitzerohero] & [Git-collaboration][gitcollaboration]), etc…
 
-* Reliability of science results can be tested by comparing your code with exsiting datasets. Can you replicate exiting results with your own tool? That will give you an interesting insight. 
+- Research reproducibility will also benefit from all of the previous suggestions, but you can add data version control (DVC) that will help track the state of your data and changes, parametrisation of code ensures that it can be rerun with different parameters easily (without changing the code) via configuration files or command line interface (follow the lecture on [Design] for these aspects). Testing by other people also helps. If someone else in your team can reproduce your results it will give you a good idea of how reproducible are your results. Finally, and for a more advanced case, it is possible to fully automatise reproducibility checks.
 
-A Tested software make it more reliable and robust. You will greatly enhance its **Reusability** and make your science more **Reproducible**.   
+* Reliability of science results can be tested by comparing your code with exsiting datasets. Can you replicate exiting
+  results with your own tool? That will give you an interesting insight.
+
+A Tested software make it more reliable and robust. You will greatly enhance its **Reusability** and make your science more **Reproducible**.
 
 ### Dissemination.
 
-Dissemination is a cornerstone of research. When it comes to research software you will have to make sure that people know where to find it and how to use it (**Findable** and **Reusable**). It comes down to three important pilars:
+Dissemination is a cornerstone of research. When it comes to research software you will have to make sure that people
+know where to find it and how to use it (**Findable** and **Reusable**). It comes down to three important pilars:
 
-* License: This is probably one of the most basic item of the software management plan. If there is no license in your software people won't know if they have the right to re-use your software. No license means that you retain all the rights to your source code and no one may reproduce, distribute or create derivative works from your code (which is the opposite of research philosophy). Please see the chapter on intellectual property and software licenses for more details **[link TBD]**.
+* License: This is probably one of the most basic item of the software management plan. If there is no license in your
+  software people won't know if they have the right to re-use your software. No license means that you retain all the
+  rights to your source code and no one may reproduce, distribute or create derivative works from your code (which is
+  the opposite of research philosophy). Please see the chapter on intellectual property and software licenses for more
+  details **[link TBD]**.
 
-* Documentation is paramount: And guess what, the main group that it will help is YOUR TEAM! Research projects often span several years with people coming in and some leaving the team. If it takes someone 6 months just to understand the software that the team is developing it is going to be a waste of time. If you want a sustainable project, write a good documentation. In addition, If you produce a software with a good documentation it will be more likely used by the community and then you might get credit for it! You should make sure that the documentation is easily accessible (e.g. a website) and tailored to future researchers and the academic community in your research domain (Lecture on [Documentation] is available in the program). Document how the software works, but not only this. Always describe how it serves a research question. 
+* Documentation is paramount: And guess what, the main group that it will help is YOUR TEAM! Research projects often
+  span several years with people coming in and some leaving the team. If it takes someone 6 months just to understand
+  the software that the team is developing it is going to be a waste of time. If you want a sustainable project, write a
+  good documentation. In addition, If you produce a software with a good documentation it will be more likely used by
+  the community and then you might get credit for it! You should make sure that the documentation is easily accessible
+  (e.g. a website) and tailored to future researchers and the academic community in your research domain (Lecture on
+  [Documentation] is available in the program). Document how the software works, but not only this. Always describe how
+  it serves a research question.
 
-* Software repositories: It is important to place your software (the released version) to a place where people can download it freely. Collaborative development platform such as github are not made to store software on the long term. Nevertheless, other platform are made for this (e.g. figshare, zenodo, etc..). This is where you should look for a long term storage. Please see chapter on dissemination for more details **[Link TBD]**.
+* Software repositories: It is important to place your software (the released version) to a place where people can
+  download it freely. Collaborative development platform such as github are not made to store software on the long
+  term. Nevertheless, other platform are made for this (e.g. figshare, zenodo, etc..). This is where you should look for
+  a long term storage. Please see chapter on dissemination for more details **[Link TBD]**.
 
 To go a little bit further, you might want to take extra step in the dissemination direction:
 
-* Publication: Once you release your software, you might want to publish it! Numerous journals accept papera about research software. Some are generalists (e.g. JOSS, JORS, SoftwareX, etc) and some are domain oriented (you can get a non exhaustive list [here](https://www.software.ac.uk/top-tip/which-journals-should-i-publish-my-software)). This is really something you should consider! It will give you a lot of visibility and allow you to get a citable paper associated to your software (you can follow the lecture on [Publishing your software] for this).
+* Publication: Once you release your software, you might want to publish it! Numerous journals accept papera about
+  research software. Some are generalists (e.g. JOSS, JORS, SoftwareX, etc) and some are domain oriented (you can get a
+  non exhaustive list [here](https://www.software.ac.uk/top-tip/which-journals-should-i-publish-my-software)). This is
+  really something you should consider! It will give you a lot of visibility and allow you to get a citable paper
+  associated to your software (you can follow the lecture on [Publishing your software] for this).
 
-* Training: If your software sees a lot of buy-in in the community and that is relatively complex to use (not all software are), you might want to train others to use it. You can do that via tutorials or training events. This is a very powerful way to give your work more visibility and a very efficient way to create collaborations!
+* Training: If your software sees a lot of buy-in in the community and that is relatively complex to use (not all
+  software are), you might want to train others to use it. You can do that via tutorials or training events. This is a
+  very powerful way to give your work more visibility and a very efficient way to create collaborations!
 
 
 ### Long term sustainability
-Maintenance of the software is tricky. We can distinguish two parts: 
+Maintenance of the software is tricky. We can distinguish two parts:
 
-* The software is in a final form, but the founding is still there: In that case it is important to identify who is in charge of the maintenance and update. You might work with totally different people than at the beginning of the project. So it is important to plan this ahead (cf previous section). A good documentation will always help the maintenance.
+* The software is in a final form, but the founding is still there: In that case it is important to identify who is in
+  charge of the maintenance and update. You might work with totally different people than at the beginning of the
+  project. So it is important to plan this ahead (cf previous section). A good documentation will always help the
+  maintenance.
 
-* The research project comes to an end (and with it, its founding). That’s the tricky situation, long term maintenance is difficult because founders do not plan for this (which happens everywhere). If you want to increase the chances that your software work in 5 or 10 years, what you could envisage to do is to distribute your software with its own computational environment. This ships your software with the required dependencies and put all this in its own bubble. This greatly enhance long term **Reproducibility** of your work. If you are interested to learn more about this, you can register to the lecture on [Reproducible Computational Environment].
+* The research project comes to an end (and with it, its founding). That’s the tricky situation, long term maintenance
+  is difficult because founders do not plan for this (which happens everywhere). If you want to increase the chances
+  that your software work in 5 or 10 years, what you could envisage to do is to distribute your software with its own
+  computational environment. This ships your software with the required dependencies and put all this in its own
+  bubble. This greatly enhance long term **Reproducibility** of your work. If you are interested to learn more about
+  this, you can register to the lecture on [Reproducible Computational Environment].
 
 
 ## Minimal version
 
-Everything that has been described previously can be quite intimidating at first. There is a lot to think about and depending on the size of your project you might not need all of these details. If you want to go with a minimal set of items to put in place you could choose the following ones:
+Everything that has been described previously can be quite intimidating at first. There is a lot to think about and
+depending on the size of your project you might not need all of these details. If you want to go with a minimal set of
+items to put in place you could use the following:
 
-* Information on what software outputs (including documentation and other related material) are expected to be produced ; 
-* Who is responsible for the development work?;
-* The version control process to be used;
-* What license will be used for each produced piece of code/data?
+1. Information on what software outputs (including documentation and other related material) are expected to be
+   produced.
+2. Who is responsible for the development work?;
+3. Which version control system is to be used?
+4. What license will be used for each produced piece of code/data?
 
-These four items should be on your list in the planning phase. 
+These four items should be on your list in the planning phase.
 
 
+[agile]: https://en.wikipedia.org/wiki/Agile_software_development
+[gitzerohero]: https://srse-git-github-zero2hero.netlify.app/
+[gitcollaboration]: https://blog.nshephard.dev/git-collaboration/
+[watefall]: https://en.wikipedia.org/wiki/Waterfall_model

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -4,9 +4,9 @@ teaching: 10
 exercises: 2
 ---
 
-:::::::::::::::::::::::::::::::::::::: questions 
+:::::::::::::::::::::::::::::::::::::: questions
 
-- How do we defne software in research?
+- How do we define software in research?
 - What is the classical software lifecycle?
 - What are the FAIR principles applied to research software?
 
@@ -22,48 +22,80 @@ exercises: 2
 
 ## What is a software in academia?
 
+It is not always easy to define what constitutes software in a research setting. The size of projects can vary from a
+small script of a few dozens of lines to a massive project with millions of lines. If you are interested in a discussion
+around a research software definition a good starting point is [_Defining Research Software: a controversial
+discussion_][defressoft]. An abbreviated summary of this paper and a pragmatic definition we use
+as a basis for this course is...
 
-It is not always easy to define what constitutes a software in research. The size of projects can vary from a small script of a few dozens of lines to a massive project with millions of lines. If you are interested in a discussion around a research software definition you can have a look [here](https://zenodo.org/records/5504016). For the shortcut version, here is a definition of research software that we are going to consider:
+::::::::::::::::::::::::::::::::::::: keypoints
 
-::::::::::::::::::::::::::::::::::::: keypoints 
-
-Research Software includes source code files, algorithms, scripts, computational workflows and executables that were created during the research process or for a research purpose. Software components (e.g., operating systems, libraries, dependencies, packages, scripts,etc.) that are used for research but were not created during or with a clear research intent should be considered software in research and not Research Software. This differentiatio nmay vary between disciplines.
+Research Software includes source code files, algorithms, scripts, computational workflows and executables that were
+created during the research process or for a research purpose. Software components (e.g., operating systems, libraries,
+dependencies, packages, scripts,etc.) that are used for research but were not created during or with a clear research
+intent should be considered software in research and not Research Software. This differentiation may vary between
+disciplines.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Reminder: The FAIR principles applied to research software
 
-The FAIR principles (Findable, Accessible, Interoperable and Reusable) where originally designed for research data in order to "enhance their reusability" (see this [Nature](https://www.nature.com/articles/sdata201618) paper). In that seminal paper, it was made clear that while data was a central aspect of research, the principles should also apply to algorithms, tools and workflows that led to the production of that data. Few years later, in 2022, a set of recommendation was published (see [here](https://zenodo.org/records/6623556#.YqCJTJNBwlw)) in order to apply these FAIR principle to research software. This are the FAIR principles adapter to research software:
+The FAIR principles (Findable, Accessible, Interoperable and Reusable) were originally designed for research data in
+order to "enhance their re-usability" (see [Wilkinson _et al_ (2016)][fair]). In this seminal paper it was made clear
+that while data was a central aspect of research, the principles should also apply to algorithms, tools and workflows
+that led to the production of that data. Few years later, in 2022, a set of recommendation was published ([Chue Hon _et
+al._ (2022)][fair4rswg]; [Barker _et al._ (2022)][fair4rs]) in order to apply these FAIR principle to research
+software. An overview of the FAIR principles adapted to research software are that...
 
+::::::::::::::::::::::::::::::::::::: keypoints
 
-::::::::::::::::::::::::::::::::::::: keypoints 
+- Findable: Software, and its associated metadata, is easy for both humans and machines to find.
 
-* Findable: Software, and its associated metadata, is easy for both humans and machines to find 
+- Accessible: Software, and its metadata, is retrievable via standardised protocols.
 
-* Accessible: Software, and its metadata, is retrievable via standardised protocols
- 
-* Interoperable: Software interoperates with other software by exchanging data and/or metadata, and/or through interaction via application programming interfaces (APIs), described through standards
+- Interoperable: Software interoperates with other software by exchanging data and/or metadata, and/or through
+  interaction via Application Programming Interfaces (APIs), described through standards.
 
-* Reusable: Software is both usable (can be executed) and reusable (can be understood, modified, built upon, or incorporated into other software)
+- Reusable: Software is both usable (can be executed) and reusable (can be understood, modified, built upon, or
+  incorporated into other software).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-## The software lifecyle
+## The software lifecycle
 
-A traditional software lifecycle (in a non-academic setup) involved the following phases:
+A traditional software lifecycle (in a non-academic setup) involves the following phases:
 
-![Traditional Software Lifecyle](fig/SLC.png){ width=50% }
+![Traditional Software Lifecycle](fig/SLC.png){ width=50% }
 
-* 1 - **Requirements and Analysis**: Requirements are gathered from stakeholders (client, users) and analysed. From this, the Software Requirement Specification document is produced outlining all funcional and non-functional requirements. The focus here is on understand what the system is supposed to do without going into details of implementation
+1. **Requirements and Analysis**: Requirements are gathered from stakeholders (client, users) and analysed. From
+  this, the Software Requirement Specification document is produced outlining all functional and non-functional
+  requirements. The focus here is on understanding what the system is supposed to do without going into the details of
+  implementation.
 
-* 2 - **System design**: That stage creates the bluepring for bilding the system. It identifies the architecture, the components and their interaction but also focusing on the details of each components (data structure, databases, input/output).
+2. **System design**: The blueprint for building the system is created. It identifies the architecture, the
+  components and their interaction but also focusing on the details of each components (data structure, databases,
+  input/output).
 
-* 3 - **Development**: This is where the coding takes place. The developer will write the code based on the SPS and ensure that it meets requirements. It is often done by creating small building blocks.
+3. **Development**: This is where the coding takes place. The developer will write the code based on the Software
+  Requirement Specification to ensure that it meets requirements. It is often done iteratively by creating small
+  building blocks.
 
-* 4 - **Integration and testing**: Once the code is written, the individual block are integrated to a complete system and various testing are conducted (e.g. unit tests, integration tests).
+4. **Integration and testing**: Once the code is written, the individual block are integrated to a complete system
+  and various testing are conducted (e.g. unit tests, integration tests).
 
-* 5 - **Deplyoment**: Once the software is fully tested and ready, it is eployed to the production environment or delivered to the client. This is at this stage that the software is available to end-users.
+5. **Deployment**: Once the software is fully tested and ready, it is deployed to the production environment or
+  delivered to the client. It is at this stage that the software is available to end-users.
 
-* 6 - **Maintenance**: At this stage, the software enters the maintenance phase where it is monitored, updated and fixed if necessary. Corrective maintenance fixes bugs, while adaptive and perfective maintenance improve the software's performance or add new functionalities. 
+6. **Maintenance**: At this stage, the software enters the maintenance phase where it is monitored, updated and fixed
+  if necessary. Corrective maintenance fixes bugs, while adaptive and perfective maintenance improve the software's
+  performance or add new functionalities.
 
-It is quite a rigid framework that does not really adapt well to changes. This framework is often called a waterfall model. Nevertheless it is possible to adapt it to research the academic framework. That what we will see in the software management plan in the next chapter. 
+It is quite a rigid framework that does not really adapt well to changes. This framework is often called a [waterfall
+model][waterfall]. Nevertheless it is possible to adapt it to research the academic framework. That what we will see in
+the software management plan in the next chapter.
+
+[defressoft]: https://doi.org/10.5281/zenodo.5504016
+[fair]: https://doi.org/10.1038/sdata.2016.18
+[fair4rs]: https://doi.org/10.1038/s41597-022-01710-x
+[fair4rswg]: https://10.5281/zenodo.5504015.
+[waterfall]: https://en.wikipedia.org/wiki/Waterfall_model

--- a/index.md
+++ b/index.md
@@ -1,9 +1,4 @@
 ---
 site: sandpaper::sandpaper_site
+title: "Summary"
 ---
-
-This is a new lesson built with [The Carpentries Workbench][workbench]. 
-
-
-[workbench]: https://carpentries.github.io/sandpaper-docs
-

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,21 +2,47 @@
 title: Setup
 ---
 
-No particular setup is needed for this part of the FAIR training program. This module is expected to last 2.5h in total and can be done in half a day.
+No particular setup is needed for this part of the FAIR training program. This module is expected to last 2.5 houts in
+total and can therefore be completed in half a day.
 
 ## Summary
 
-The application of the FAIR principles (Findable, Accessible, Interoperable, Reusable) to a research software project is easier when you plan the development of your software. Considering who is in charge of the development, what tools will be used, who will be in charge of its long term maintenance and where are the potential risks related to software development are all important aspects of a successful software project. This course will introduce these ideas in the context of creating FAIR software for your research. Planning the development of your research software will help you with organisation and resource management, long term sustainability, and intellectual property aspects.
+The application of the [FAIR principles][fair] (Findable, Accessible, Interoperable, Reusable) to a [research
+software][fair4rs] project is easier when you plan the development of your software. Considering who is in charge of the
+development, what tools will be used, who will be in charge of its long term maintenance and where are the potential
+risks related to software development are all important aspects of a successful software project. This course will
+introduce these ideas in the context of creating FAIR software for your research. Planning the development of your
+research software will help you with organisation and resource management, long term sustainability, and intellectual
+property aspects.
 
-We will start by introducing some definitions (what is a research software? How a software is traditionaly developed?) and then dive into the concept of research software management plans (SMPs) and we will discuss why it is important to plan for the development of your software. 
+We will start by introducing some definitions (What is a research software? How a software is traditionaly developed?)
+and then dive into the concept of research Software Management Plans (SMPs) and discuss why it is important to plan for
+the development of your software.
 
-Then we will discuss two important aspects of software development in the context of software in academia: 
+Then are two important aspects of software development in the context of software in academia which influence the
+development of the Software Management Plan:
 
-* **Licences and Intellectual Property**: Software is a creative work and as soon as it is created it automatically attracts copyright protection. This means that if you want other people to be able to use your software without having to ask you directly you need to apply a licence to it. We will look at why licensing matters, how to choose a licence and what the implications are when you want to build on other people’s openly licensed software.
+- **Licences and Intellectual Property**: Software is a creative work and as soon as it is created it automatically
+  attracts copyright protection. This means that if you want other people to be able to use your software without having
+  to ask you directly you need to apply a licence to it. We will look at why licensing matters, how to choose a licence
+  and what the implications are when you want to build on other people’s openly licensed software.
 
-* **Dissemination**: While putting your software online certainly helps it satisfy the FAIR principles, simply doing so might not be enough for other researchers to actually find and utilise what you’ve put out there. It’s important to know the benefits and issues with where you store and publish your data, and to make the most of the tools these platforms provide, such as Digital Object Identifiers (DOIs). It’s also important to know best practice for how to increase the visibility and citability of your work in cases where your chosen platform lacks these features. We will introduce and explore worked examples of elements that you should consider when publishing your software, which will help you easily reference your work, and also help make it more findable and reusable by others.
+- **Dissemination**: While putting your software online certainly helps it satisfy the FAIR principles, simply doing so
+  might not be enough for other researchers to actually find and utilise what you’ve put out there. It’s important to
+  know the benefits and issues around where you store and publish your software and data, and to make the most of the
+  tools the different platforms provide, such as Digital Object Identifiers (DOIs). It’s also important to know good
+  practice for how to increase the visibility and citability of your work in cases where your chosen platform lacks
+  these features.
+
+The course uses worked examples to introduce and explore elements that you should consider when publishing your
+software which will help you easily reference your work and help make it more findable and reusable by others.
 
 
 ## Target audience
-This course is aimed at researchers, including postgraduate researchers, who write software (whether a few scripts or something more substantial) as part of their research and wish to bring open research best practice to their project or team.
-Outline
+
+This course is aimed at researchers, including postgraduate researchers, who write software (whether a few scripts or
+something more substantial) as part of their research and wish to bring open research best practice to their project or
+team.
+
+[fair]: https://www.nature.com/articles/sdata201618
+[fair4rs]: https://www.nature.com/articles/s41597-022-01710-x

--- a/links.md
+++ b/links.md
@@ -1,16 +1,4 @@
-<!-- 
+<!--
 Place links that you need to refer to multiple times across pages here. Delete
-any links that you are not going to use. 
+any links that you are not going to use.
  -->
-
-[pandoc]: https://pandoc.org/MANUAL.html
-[r-markdown]: https://rmarkdown.rstudio.com/
-[rstudio]: https://www.rstudio.com/
-[carpentries-workbench]: https://carpentries.github.io/sandpaper-docs/
-[Git-Beginners]: https://mydevelopment.csod.com/ui/lms-learning-details/app/event/d4d09f67-097b-4451-8ddb-86cb90636c06
-[Git-collaboration]: https://mydevelopment.csod.com/ui/lms-learning-details/app/event/6197989b-bef2-4352-a14b-02c4f45bbca6
-[testing]: https://mydevelopment.csod.com/ui/lms-learning-details/app/event/460c53c5-40e4-4c97-ab4f-144213544026
-[Design your code]:https://mydevelopment.csod.com/ui/lms-learning-details/app/event/d3c2cca5-d894-44b6-a79b-e93dea7a7c94
-[Reproducible Computational Environment]: https://mydevelopment.csod.com/ui/lms-learning-details/app/event/e30c407d-c97d-44a0-b3fd-4e87f95c4789
-[Publishing your software]: https://mydevelopment.csod.com/ui/lms-learning-details/app/event/bbbf3532-826c-4440-bb01-06a929d3b5ec
-[Documentation]: https://mydevelopment.csod.com/ui/lms-learning-details/app/event/7c81f9fd-656f-4ae9-ba48-bc83afe81cc2


### PR DESCRIPTION

## Global changes

+ Adds configuration files for [pre-commit](https://pre-commit.com) and
[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) and applies the rules to files in the top level directory.

## `index.md`

+ Found in the [NEWS.md](https://github.com/carpentries/sandpaper/blob/d566e2dd87540195e1b4e856f82ace8ad975346c/NEWS.md?plain=1#L669) how to set the title of the main page to change the title of the main front page by adding...

```yaml
---
title: "Whatever title you want"
---
```

to the header of `index.md`.

## `learners/setup.md`

+ Wrap lines to 120 characters (makes referencing errors slightly easier and is something [mardownlint-cli2](We will
  introduce and explore) complains about)
+ Reduced use of "_We will_" phrase.
+ `best practices` - `good practices` (pet dislike of mine as `best` suggests not much room for improvement and that if people don't do it they're failing)
+ Remove `Outline` at end of last paragraph.
+ Split sentence about use of worked examples out of bulleted point and tweaked wording.

## `episodes/introduction.md

+ Linting with `markdownlint-cli2`, including line wrapping.
+ Fixing some tpyos.
+ DOI's for citations and in-line author citation.

## `episodes/SNP_for_research.md`

Split this review into two to make it easier to see the changes, the first here mainly hard wraps long lines at 120 characters making it easier to find lines and in-keeping with the linting of `markdownlint-cli2`.

I'd already made a few changes before realising it would be easier to make sense of the changes if split into to commits.

+ Rewording in multiple places.
+ Some punctuation.
+ Links to other modules (although I appreciate these may change and be to the relevant myDevelopment page.
+ Links to many other resources and sites that are mentioned.
+ Splitting of some bullet points.
