### PR TITLE
tidy: Use custom title in index.md; tidy a few other things

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,23 +63,24 @@ contact: 'romain.thomas@sheffield.ac.uk'
 # - another-learner.md
 
 # Order of episodes in your lesson
-episodes: 
+episodes:
 - introduction.md
 - SMP_for_research.md
 - Intellectual_property_and_licences.md
 - Dissemination_impact.md
 
 # Information for Learners
-learners: 
+learners:
 
 # Information for Instructors
-instructors: 
+instructors:
 
 # Learner Profiles
-profiles: 
+profiles:
 
 # Customisation ---------------------------------------------
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 varnish: RSE-Sheffield/uos-varnish@main
+sandpaper: carpentries/sandpaper@allow-custom-title-340

--- a/episodes/SMP_for_research.md
+++ b/episodes/SMP_for_research.md
@@ -15,7 +15,7 @@ exercises: 0
 ::::::::::::::::::::::::::::::::::::: objectives
 
 - Understand the main points of a software management plan.
-- What are the main questions you should ask yourself before diving into the coding part.
+- Know the main questions you should ask yourself before diving into coding.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -209,9 +209,10 @@ To go a little bit further, you might want to take extra step in the disseminati
 
 - **Publication**: Once you release your software, you might want to publish it! Numerous journals accept papera about
   research software. Some are generalists (e.g. [JOSS][joss], JORS, [SoftwareX][softwarex] to name a few) and some are
-  domain oriented (you can get a non-exhaustive list [here][softwarepublishing])). A dedicated paper describing your
-  software is really something you should consider! It will give you a lot of visibility and allow you to get a citable
-  paper associated to your software (you can follow the lecture on [Publishing your software] for this).
+  domain oriented (you can get a non-exhaustive list from the [Software Sustainability
+  Institute][softwarepublishing])). A dedicated paper describing your software is really something you should consider!
+  It will give you a lot of visibility and allow you to get a citable paper associated to your software (you can follow
+  the lecture on [Publishing your software] for this).
 
 - **Training**: If your software sees a lot of buy-in from the community and is relatively complex to use (not all
   software is), you might want to train others to use it. You can do that via tutorials and/or training events. This is

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -15,7 +15,7 @@ exercises: 2
 ::::::::::::::::::::::::::::::::::::: objectives
 
 - Understand the definition of software in research.
-- Understand the FAIR principles applied to research software.
+- Understand the FAIR principles as applied to research software.
 - Get to know (briefly) the software lifecycle.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 site: sandpaper::sandpaper_site
+title: "Summary"
 ---
 
 No particular setup is needed for this module of the FAIR training program. This module is expected to last 2.5 hours in

--- a/index.md
+++ b/index.md
@@ -2,3 +2,6 @@
 site: sandpaper::sandpaper_site
 title: "Summary"
 ---
+
+No particular setup is needed for this module of the FAIR training program. This module is expected to last 2.5 hours in
+total and can therefore be completed in half a day.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -7,8 +7,8 @@ title: Setup
 
 The application of the [FAIR principles][fair] (Findable, Accessible, Interoperable, Reusable) to a [research
 software][fair4rs] project is easier when you plan the development of your software. Considering who is in charge of the
-development, what tools will be used, who will be in charge of its long term maintenance and where are the potential
-risks related to software development are all important aspects of a successful software project. This course will
+development, what tools will be used, who will be in charge of its long term maintenance and what the potential risks
+are related to software development are all important aspects of a successful software project. This course will
 introduce these ideas in the context of creating FAIR software for your research. Planning the development of your
 research software will help you with organisation and resource management, long term sustainability, and intellectual
 property aspects.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,10 +2,8 @@
 title: Setup
 ---
 
-No particular setup is needed for this part of the FAIR training program. This module is expected to last 2.5 houts in
-total and can therefore be completed in half a day.
 
-## Summary
+## Overview
 
 The application of the [FAIR principles][fair] (Findable, Accessible, Interoperable, Reusable) to a [research
 software][fair4rs] project is easier when you plan the development of your software. Considering who is in charge of the
@@ -15,7 +13,7 @@ introduce these ideas in the context of creating FAIR software for your research
 research software will help you with organisation and resource management, long term sustainability, and intellectual
 property aspects.
 
-We will start by introducing some definitions (What is a research software? How a software is traditionaly developed?)
+We will start by introducing some definitions (What is a research software? How software is traditionally developed?)
 and then dive into the concept of research Software Management Plans (SMPs) and discuss why it is important to plan for
 the development of your software.
 
@@ -36,7 +34,6 @@ development of the Software Management Plan:
 
 The course uses worked examples to introduce and explore elements that you should consider when publishing your
 software which will help you easily reference your work and help make it more findable and reusable by others.
-
 
 ## Target audience
 


### PR DESCRIPTION
I actually went and read the commit that introduced the use of custom titles in `index.md` as I should have done in the first instance and a tweak needs to be made to `config.yaml` (see [342](https://github.com/carpentries/sandpaper/pull/342#issuecomment-1258738205)) which is included in this commit.

However, testing I found that we couldn't have just a YAML header in `index.md` this caused the error...

```
 ── Creating homepage ───────────────────────────────────────────────────────────
  Error in UseMethod("xml_find_first") :
    no applicable method for 'xml_find_first' applied to an object of class "xml_document"
```

I've therefore moved the opening paragraph from `learners/setup.md` > `index.md` and it seems to work.

Took the opportunity to improve a few other minor things (there was a complaint about the use of an uninformative `here` as the text for a hyperlink).

This time I've checked _before_ making a pull request and the pages render as we would like.